### PR TITLE
feat: add Dockerfile for ease of use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:3-bullseye
+
+RUN apt-get install gcc
+
+WORKDIR /opt
+RUN git clone --recurse-submodules https://github.com/HARICA-official/onion-csr.git
+
+WORKDIR /opt/onion-csr
+RUN gem install ffi && \
+    gcc -shared -o libed25519.so -fPIC ed25519/src/*.c
+
+CMD ["ruby", "onion-csr.rb"]


### PR DESCRIPTION
Would be nice to include this simple Dockerfile for folks to reference if their local system doesn't meet the specified requirements and to eliminate environment-specific errors (as I had during use, ran into a cryptic ruby error during the `ASN1.decode` call). 